### PR TITLE
closes #7

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -128,7 +128,7 @@ export const dataSources = [cellline, tissue];
 export function chooseDataSource(desc: any): IDataSourceConfig {
 
   if (typeof(desc) === 'object') {
-    return desc.sampleType === 'Tissue' ? tissue : cellline;
+    return desc.sampleType === 'Tissue' || desc.idtype === 'Tissue' ? tissue : cellline;
   }
 
   switch (desc) {


### PR DESCRIPTION
The error was that `sampleType` did not exist in the description and therefore cell line was returned

However a quick search showed that `sampleType` is only used in one interface and at this place. Should we remove it and use `idtype` instead?