### PR TITLE
avoid calling the selection adapter, when lineup is rebuilt anyway

### DIFF
--- a/src/views/DependentGeneTable.ts
+++ b/src/views/DependentGeneTable.ts
@@ -51,7 +51,6 @@ export default class DependentGeneTable extends ARankingView {
   }
 
   protected parameterChanged(name: string) {
-    super.parameterChanged(name, false);
     this.rebuild();
   }
 

--- a/src/views/DependentSampleTable.ts
+++ b/src/views/DependentSampleTable.ts
@@ -59,7 +59,6 @@ export default class DependentSampleTable extends ARankingView {
   }
 
   protected parameterChanged(name: string) {
-    super.parameterChanged(name, false);
     this.rebuild();
   }
 


### PR DESCRIPTION
requires https://github.com/datavisyn/tdp_core/pull/63
closes Caleydo/tdp_bi_bioinfodb#713

the build is failing since these changes require changes in tdp_core, which is a dependency with an indirection via tdp_gene and I don't want to touch tdp_gene to fix the dependency