### PR TITLE
Resolve ids in selection adapter of DependentTable

### DIFF
--- a/src/views/DependentGeneTable.ts
+++ b/src/views/DependentGeneTable.ts
@@ -15,7 +15,7 @@ import {
 } from '../config';
 import {ParameterFormIds, FORM_GENE_FILTER} from '../forms';
 import {FormElementType} from 'tdp_core/src/form';
-import {ISelection, IViewContext} from 'tdp_core/src/views';
+import {ISelection, IViewContext, resolveIds} from 'tdp_core/src/views';
 import {getTDPDesc, getTDPFilteredRows, getTDPScore, IServerColumn} from 'tdp_core/src/rest';
 import {postProcessScore, subTypeDesc} from './utils';
 import {toFilter} from 'tdp_core/src/lineup';
@@ -61,8 +61,14 @@ export default class DependentGeneTable extends ARankingView {
 
   protected createSelectionAdapter() {
     return single({
-      createDesc: (_id: number, id: string) => subTypeDesc(this.dataSubType, _id, id),
-      loadData: (_id: number, id: string) => this.loadSelectionColumnData(id)
+      createDesc: async (_id: number, id: string) => {
+        const ids = await resolveIds(this.selection.idtype, [_id], this.dataSource.idType);
+        return subTypeDesc(this.dataSubType, _id, ids[0]);
+      },
+      loadData: async (_id: number, id: string) => {
+        const ids = await resolveIds(this.selection.idtype, [_id], this.dataSource.idType);
+        return this.loadSelectionColumnData(ids[0]);
+      }
     });
   }
 


### PR DESCRIPTION
**Example**

* Create a fictive repo _tdp_personsdb_ with the idtype _persons_ and the DB mapping from _persons_ to _tissue_
* The selection of patients can be mapped to tissues
* Tissues are then added as columns to DependentTable (showing genes)
* Thus a person view can open a gene table and add tissues as columns
* Ordino suggests gene-related views for selected persons

![grafik](https://user-images.githubusercontent.com/5851088/61050995-8922a500-a3e8-11e9-8c31-6321ebceb4b0.png)

**Before this PR**

Only the _Database Info_ was working correctly. All other views only show the selected ids 1, 2, 3 as additional columns in LineUp

![grafik](https://user-images.githubusercontent.com/5851088/61051384-2aa9f680-a3e9-11e9-91ec-31f6208af9f2.png)


**After this PR**

LineUp view show the correct (related) tissue name and data for selected persons

![grafik](https://user-images.githubusercontent.com/5851088/61051440-47dec500-a3e9-11e9-814e-f0f8906def0c.png)

