### PR TITLE
Fix filter columns in score DB view

### DIFF
--- a/tdp_publicdb/query_score.py
+++ b/tdp_publicdb/query_score.py
@@ -25,7 +25,7 @@ def create_gene_sample_score(views, gene, sample, data, prefix='', inline_aggreg
     .call(inject_where) \
     .arg('name') \
     .call(callback) \
-    .filters(sample.columns) \
+    .filters(gene.columns) \
     .call(_common) \
     .build()
 


### PR DESCRIPTION
Fixes #58

### Summary

The wrong entity was used to filter for incoming parameters. Hence, all filter parameters from the URL were invalid and result in an error 400. Now, the correct entity is provided as filter for the DB view. 

The result is that the correct filtered subset (and not all) scores are returned.

![grafik](https://user-images.githubusercontent.com/5851088/66564566-8e66cb80-eb60-11e9-8302-5494e20f8a55.png)

![grafik](https://user-images.githubusercontent.com/5851088/66564606-ab030380-eb60-11e9-9973-71bdb35b0c70.png)

See https://github.com/Caleydo/tdp_publicdb/issues/58#issuecomment-540522968 for further explanation.