### PR TITLE
Update to Typescript 3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,10 +111,10 @@
     "webpack-dev-server": "2.4.2"
   },
   "dependencies": {
-    "tdp_gene": "github:Caleydo/tdp_gene#develop"
+    "tdp_gene": "github:Caleydo/tdp_gene#typescript_3.8"
   },
   "optionalDependencies": {
-    "ordino": "github:Caleydo/ordino#develop",
-    "dTiles": "github:datavisyn/dTiles#develop"
+    "ordino": "github:Caleydo/ordino#typescript_3.8",
+    "dTiles": "github:datavisyn/dTiles#typescript_3.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -102,10 +102,10 @@
     "style-loader": "0.16.1",
     "thread-loader": "1.1.2",
     "ts-loader": "4.0.1",
-    "tslib": "~1.10.0",
+    "tslib": "~1.11.0",
     "tslint": "5.9.1",
     "typedoc": "~0.16.9",
-    "typescript": "~3.8.1-rc",
+    "typescript": "~3.8.2",
     "url-loader": "0.5.8",
     "webpack": "2.3.3",
     "webpack-dev-server": "2.4.2"

--- a/package.json
+++ b/package.json
@@ -102,10 +102,10 @@
     "style-loader": "0.16.1",
     "thread-loader": "1.1.2",
     "ts-loader": "4.0.1",
-    "tslib": "1.9.0",
+    "tslib": "~1.10.0",
     "tslint": "5.9.1",
-    "typedoc": "0.11.1",
-    "typescript": "2.8.1",
+    "typedoc": "~0.16.9",
+    "typescript": "~3.8.1-rc",
     "url-loader": "0.5.8",
     "webpack": "2.3.3",
     "webpack-dev-server": "2.4.2"

--- a/package.json
+++ b/package.json
@@ -111,10 +111,10 @@
     "webpack-dev-server": "2.4.2"
   },
   "dependencies": {
-    "tdp_gene": "github:Caleydo/tdp_gene#typescript_3.8"
+    "tdp_gene": "github:Caleydo/tdp_gene#develop"
   },
   "optionalDependencies": {
-    "ordino": "github:Caleydo/ordino#typescript_3.8",
-    "dTiles": "github:datavisyn/dTiles#typescript_3.8"
+    "ordino": "github:Caleydo/ordino#develop",
+    "dTiles": "github:datavisyn/dTiles#develop"
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "extract-loader": "0.1.0",
     "extract-text-webpack-plugin": "2.1.0",
     "file-loader": "0.11.1",
-    "fork-ts-checker-webpack-plugin": "0.4.1",
+    "fork-ts-checker-webpack-plugin": "0.4.4",
     "html-loader": "0.4.5",
     "ifdef-loader": "2.0.0",
     "imports-loader": "0.7.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "node",
     "jsx": "react",
     "experimentalDecorators": true,
+    "downlevelIteration": true, // required as long as target is `es5`
     "lib": [
       "dom",
       "es2015",


### PR DESCRIPTION
Closes #75 

### Summary
* update to typescript `v3.8` and typedoc `v0.16.9`
* switch branches in _package.json_
* update `tslib`
* set `downlevelIteration": true` in _tsconfig.json_ 