### PR TITLE
Update docker image to  postgress12.1

### DIFF
--- a/deploy/docker-compose.partial.yml
+++ b/deploy/docker-compose.partial.yml
@@ -6,7 +6,7 @@ services:
     links:
     - db_publicdb:publicdb
   db_publicdb:
-    image: postgres:9.6-alpine
+    image: postgres:12.1
     environment:
        POSTGRES_USER: publicdb
        POSTGRES_PASSWORD: publicdb


### PR DESCRIPTION
Closes Caleydo/tdp_publicdb#82

### Summary

Updated the image of the `db_publicdb` container from `9.6-alpine` to `12.1` to match the required 
`hg38 database` postgres version.
