### PR TITLE
 Add pgAdmin container docker-compose-debug.partial.yml

### DIFF
--- a/deploy/docker-compose-debug.partial.yml
+++ b/deploy/docker-compose-debug.partial.yml
@@ -3,3 +3,19 @@ services:
   db_publicdb:
     ports:
       - '5432:5432'
+  pgadmin4:
+    image: "dpage/pgadmin4:latest"
+    depends_on:
+      - db_publicdb
+    links:
+      - "db_publicdb:postgres"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: pgadmin4@pgadmin.org
+      PGADMIN_DEFAULT_PASSWORD: admin
+    ports:
+      - "5050:80"
+    volumes:
+      - "pgadmin4_data:/pgadmin"
+      - "./_backup:/backup"
+volumes:
+  pgadmin4_data:


### PR DESCRIPTION
Closes Caleydo/tdp_publicdb#83
Wiki entry https://wiki.datavisyn.io/internal/projects/ordino

For this feature to function properly the issue phovea/phovea_server#119
has to be fixed and merged.
### Summary

We added the pgAdmin container with the below configuration to the 
docker-compose-debug.partial.yml file.

```yml
pgadmin4:
    image: "dpage/pgadmin4:latest"
    depends_on:
      - db_publicdb
    links:
      - "db_publicdb:postgres"
    environment:
      PGADMIN_DEFAULT_EMAIL: pgadmin4@pgadmin.org
      PGADMIN_DEFAULT_PASSWORD: admin
    ports:
      - "5050:80"
    volumes:
      - "pgadmin4_data:/pgadmin"
      - "./_backup:/backup"
volumes:
  pgadmin4_data:

```
We decided to use the image **dpage/pgadmin4** instead of  **thajeztah/pgadmin4**
because the former is maintained more and the latter isn't anymore.

#### How to use  docker-compose-debug.yml 

The individual **docker-compose.partial.yml** files get composed into **docker-compose.yml**
in the workspace, when the command  `yo phovea:update` gets executed.

The same way the individual **docker-compose-debug.partial.yml**  files get composed into **docker-compose-debug.yml**.

The **docker-compose-debug.yml** is meant  to overwrite or extend the **docker-compose.yml** file. That can be done by running:
* ` docker-compose -f docker-compose.yml -f docker-compose-debug.yml up`  to start the containers.
* ` docker-compose -f docker-compose.yml -f docker-compose-debug.yml down`  to stop them.

Alternatively the **docker-compose debug.cmd** can be used to achieve the same result, so :
* `./docker-compose-debug up`
* `./docker-compose-debug down`

