### PR TITLE
Skip non-string values in detectors

### DIFF
--- a/src/GeneSymbolDetector.ts
+++ b/src/GeneSymbolDetector.ts
@@ -1,12 +1,12 @@
 import {getTDPData} from 'tdp_core/src/rest';
 
-async function detectIDType(data: any[], accessor: (row: any) => string, sampleSize: number) {
+async function detectIDType(data: any[], accessor: (row: any) => string, sampleSize: number): Promise<number> {
   const values = [];
   let validSize = 0;
   for(let i = 0; i < sampleSize; ++i) {
     const v = accessor(data[i]);
 
-    if (!v || v.trim().length === 0) {
+    if (v == null || typeof(v) !== 'string' || v.trim().length === 0) {
       continue; //skip empty samples
     }
     values.push(v);

--- a/src/GeneSymbolDetector.ts
+++ b/src/GeneSymbolDetector.ts
@@ -1,5 +1,13 @@
 import {getTDPData} from 'tdp_core/src/rest';
 
+/**
+ * Detect gene symbols from a data array by checking the strings against the database.
+ * The function returns a number between 0 and 1 defining the fraction of matching genes in the data array.
+ *
+ * @param data Data array with objects or strings
+ * @param accessor Accessor function to retrieve a certain field from a data item
+ * @param sampleSize Number of samples to test; can be used to limit iterations for large arrays
+ */
 async function detectIDType(data: any[], accessor: (row: any) => string, sampleSize: number): Promise<number> {
   const values = [];
   let validSize = 0;

--- a/src/IDTypeDetector.ts
+++ b/src/IDTypeDetector.ts
@@ -16,7 +16,7 @@ async function detectIDType(data: any[], accessor: (row: any) => string, sampleS
   for(let i = 0; i < testSize; ++i) {
     const v = accessor(data[i]);
 
-    if (v == null || v.trim().length === 0) {
+    if (v == null || typeof(v) !== 'string' || v.trim().length === 0) {
       continue; //skip empty samples
     }
     values.push(v);

--- a/src/IDTypeDetector.ts
+++ b/src/IDTypeDetector.ts
@@ -5,6 +5,15 @@ interface IIDTypeDetectorOptions {
   sampleType: string;
 }
 
+/**
+ * Detect sample ids from a data array by checking the values against the database.
+ * The function returns a number between 0 and 1 defining the fraction of matching genes in the data array.
+ *
+ * @param data Data array with objects or strings
+ * @param accessor Accessor function to retrieve a certain field from a data item
+ * @param sampleSize Number of samples to test; can be used to limit iterations for large arrays
+ * @param options Options to provide the IDType
+ */
 async function detectIDType(data: any[], accessor: (row: any) => string, sampleSize: number, options: IIDTypeDetectorOptions): Promise<number> {
   const testSize = Math.min(data.length, sampleSize);
   if (testSize <= 0) {


### PR DESCRIPTION
Fixes #109

### Summary

Check only string values and skip all other variable types.