### PR TITLE
Remove madge from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "typescript": "~3.9.7"
   },
   "dependencies": {
-    "madge": "^3.9.1",
     "tdp_gene": "github:Caleydo/tdp_gene#develop"
   },
   "optionalDependencies": {


### PR DESCRIPTION
This PR removes [madge](https://github.com/pahen/madge) from dependencies.

> Madge is a developer tool for generating a visual graph of your module dependencies, finding circular dependencies, and give you other useful info.

With Madge dependencies can be analyzed. It is not necessary to include it in the dependencies all the time though and it should be installed on-demand when doing an analysis.

