### PR TITLE
Pin greenlet version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 psycopg2==2.8.4
 -e git+https://github.com/datavisyn/tdp_core.git@develop#egg=tdp_core
+
+# greenlet is necessary v0.4.16 since v0.4.17 breaks the build
+greenlet==0.4.16


### PR DESCRIPTION
### Summary
The new version v0.4.17 breaks the build and terminates the API container with the error: Segmentation fault (core dumped). Using the previous version 0.4.16 fixes the build for now.