### PR TITLE
Removed dTiles from phovea_registry

### DIFF
--- a/phovea_registry.js
+++ b/phovea_registry.js
@@ -15,8 +15,5 @@ import 'tdp_gene/phovea_registry.js';
 /// #if include('ordino')
 import 'ordino/phovea_registry.js';
 /// #endif
-/// #if include('dTiles')
-import 'dTiles/phovea_registry.js';
-/// #endif
 //self
 PluginRegistry.getInstance().register('tdp_publicdb',reg);


### PR DESCRIPTION
tdp_publicdb does not have dTiles anymore, such that it also shouldn't register it. If dTiles and tdp_publicdb are used together, they have to be in the product together. 