### PR TITLE
Show CoExpression messages / errors

### DIFF
--- a/src/views/ACoExpression.ts
+++ b/src/views/ACoExpression.ts
@@ -192,7 +192,7 @@ export abstract class ACoExpression extends AD3View {
     const noData = refGeneExpression == null || refGeneExpression.length === 0;
 
     if (isEmpty) {
-      this.$errorMessage.text('Select two or more genes.').attr('hidden', false);
+      this.$errorMessage.text('Select two or more genes.').attr('hidden', null);
       this.$node.selectAll('div.plots').remove();
       this.color.domain([]); // reset
       ViewUtils.legend(<HTMLElement>this.$legend.node(), this.color);
@@ -200,7 +200,7 @@ export abstract class ACoExpression extends AD3View {
     }
 
     if (noData) {
-      this.$errorMessage.text(this.getNoDataErrorMessage(refGene)).attr('hidden', false);
+      this.$errorMessage.text(this.getNoDataErrorMessage(refGene)).attr('hidden', null);
       this.$node.selectAll('div.plots').remove();
       this.color.domain([]); // reset
       ViewUtils.legend(<HTMLElement>this.$legend.node(), this.color);
@@ -214,7 +214,7 @@ export abstract class ACoExpression extends AD3View {
       });
 
     // show/hide message and loading indicator if two less genes are selected
-    this.$errorMessage.attr('hidden', data.length > 0);
+    this.$errorMessage.attr('hidden', data.length > 0 || null);
     this.setBusy(data.length > 0);
 
     const $plots = this.$node.selectAll('div.plots').data(data, (d) => d.id.toString());

--- a/src/views/ACoExpression.ts
+++ b/src/views/ACoExpression.ts
@@ -60,7 +60,7 @@ export abstract class ACoExpression extends AD3View {
     this.$node.classed('coExpression', true);
     this.$node.classed('multiple', true);
 
-    this.$errorMessage = this.$node.append('p').classed('nodata', true).attr('hidden', true);
+    this.$errorMessage = this.$node.append('div').attr('class', 'nodata alert alert-warning').attr('hidden', true);
 
     this.$legend = this.$node.append('div');
 
@@ -192,7 +192,7 @@ export abstract class ACoExpression extends AD3View {
     const noData = refGeneExpression == null || refGeneExpression.length === 0;
 
     if (isEmpty) {
-      this.$errorMessage.text('Select two or more genes.').attr('hidden', null);
+      this.$errorMessage.text('Please select two or more genes.').attr('hidden', null);
       this.$node.selectAll('div.plots').remove();
       this.color.domain([]); // reset
       ViewUtils.legend(<HTMLElement>this.$legend.node(), this.color);


### PR DESCRIPTION
Closes https://github.com/Caleydo/tdp_bi_bioinfodb/issues/1391

### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The issue is that we were doing `element.attr(hidden, false)`. That usually works, but bootstrap adds the 
style 
```
[hidden]:{
display: none !important;
}
```
in it's `_reboot.scss` file (tourdino does the same which is redundant [_global.scss](https://github.com/Caleydo/tourdino/blob/d8e32139cee92ec83eaaaf97f506147228aa7e3e/src/scss/base/_global.scss#L2-L4))

This probably used to work in an earlier version of bootstrap but changed with B5
The correct way is `element.attr(hidden, null)` which removes the attribute. This is what we do in the core when using the hidden attribute

 - Used an `alert warning` for the selection message and the no data found message.



### Screenshots

![gr](https://user-images.githubusercontent.com/51322092/192753395-3f8f632e-f34d-4063-b0bc-65a8ea2d6d11.png)

![gr1](https://user-images.githubusercontent.com/51322092/192753648-5fa47275-8a39-4823-b6b3-f6bfd57ca28c.png)

