### PR TITLE
fix: drug name search when scientific name is undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ package-lock.json
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# venv
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ package-lock.json
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
-
-# venv
-.venv/

--- a/src/common/GeneUtils.ts
+++ b/src/common/GeneUtils.ts
@@ -125,7 +125,7 @@ export class GeneUtils {
   static formatDrug(item: ISelect3Item<IDrugData>, node: HTMLElement, mode: 'result' | 'selection', currentSearchQuery?: RegExp) {
     if (mode === 'result') {
       // show scientific name if is different from the drug id
-      const showScientificName = item.id.toLocaleLowerCase() !== item.data.scientificname.toLocaleLowerCase();
+      const showScientificName = item.data.scientificname && item.id.toLocaleLowerCase() !== item.data.scientificname.toLocaleLowerCase();
       // highlight match
       return `${item.id.replace(currentSearchQuery!, Select3Utils.highlightMatch)}<br>
       ${


### PR DESCRIPTION
Closes https://github.com/Caleydo/tdp_bi_bioinfodb/issues/1415, https://github.com/Caleydo/tdp_bi_bioinfodb/issues/1417

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- For some drugs the scientific name is null which causes the error described in the issue
- For example, searching for BI00... would yield a drug without a scientific name
- Probably happens more often in the BI database since they probably have more internal drugs without  a scientific name i.e., when searching for `kr`
- This also fixes the pagination. In my tests the pagination broke when scrolling to a drug without a scientifc name.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
